### PR TITLE
Fix some ES log paths

### DIFF
--- a/salt/elasticsearch/elasticsearch.yml
+++ b/salt/elasticsearch/elasticsearch.yml
@@ -39,7 +39,7 @@ path.data: /var/lib/elasticsearch
 #
 # Path to log files:
 #
-path.logs: /var/lib/elasticsearch
+path.logs: /var/log/elasticsearch
 #
 # ----------------------------------- Memory -----------------------------------
 #

--- a/salt/elasticsearch/jvm.options
+++ b/salt/elasticsearch/jvm.options
@@ -74,10 +74,10 @@
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
 8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:logs/gc.log
+8:-Xloggc:/var/log/elasticsearch/gc.log
 8:-XX:+UseGCLogFileRotation
 8:-XX:NumberOfGCLogFiles=32
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-# 9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m


### PR DESCRIPTION
Didn't spot until now that we were logging outside of `/var/log`.