### PR TITLE
Allow for disabling of bg-save

### DIFF
--- a/salt/redis/redis.conf
+++ b/salt/redis/redis.conf
@@ -221,9 +221,13 @@ always-show-logo yes
 #
 #   save ""
 
+{% if redis.get('enable-bg-saves', True) %}
 save 900 1
 save 300 10
 save 60 10000
+{% else %}
+save ""
+{% endif %}
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
By default this should allow bg-saves and we can disable it for cache instances through the redis config in infrastructure