### PR TITLE
Bump otelcol contrib default version

### DIFF
--- a/salt/otelcol-contrib/map.jinja
+++ b/salt/otelcol-contrib/map.jinja
@@ -5,10 +5,10 @@
             'extra_capabilities': [],
         },
         'default': {
-            'version_info': '0.117.0 sha256=005bef5fcc133bd74a868fe1e9b86bc17dc6f4da85e31633c73b75fac2c47e7b',
+            'version_info': '0.130.1 sha256=795d5900a0b60140b99e27aa9ccdfb04db4ebfac5001332ad1db530253e215cd',
         },
         'arm64': {
-            'version_info': '0.117.0 sha256=15d4aa9fab23910e80d40e515bbe079b5d9bc736555388b62708eaf883f928ab',
+            'version_info': '0.130.1 sha256=ca458dec13c922cdd558eefe0efa7adfa09c7eeec195c5ae3448a5ae20ab5ede',
         },
     },
     base='base',


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.130.1

ES9 supported in v0.129.0+
https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.129.0